### PR TITLE
Some fixes, plus c++ compilation

### DIFF
--- a/include/librs232/rs232.h
+++ b/include/librs232/rs232.h
@@ -9,10 +9,10 @@
  * copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following
  * conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -49,6 +49,9 @@
 #else
  #include "librs232/rs232_posix.h"
 #endif
+
+/*Ensure destination string is zero terminated*/
+#define strncpyz(dest, src, size) strncpy(dest, src, size); dest[size-1]='\0'
 
 #ifdef RS232_DEBUG
 const char* rs232_hex_dump(const void *data, unsigned int len);
@@ -219,8 +222,5 @@ RS232_LIB const char * rs232_strflow(unsigned int flow);
 RS232_LIB const char * rs232_strdtr(unsigned int dtr);
 RS232_LIB const char * rs232_strrts(unsigned int rts);
 RS232_LIB unsigned int rs232_fd(struct rs232_port_t *p);
-
-RS232_LIB unsigned int rs232_in_qeue(struct rs232_port_t *p, unsigned int *in_bytes);
-RS232_LIB void rs232_in_qeue_clear(struct rs232_port_t *p);
 
 #endif /* __LIBRS232_H__ */

--- a/src/rs232.c
+++ b/src/rs232.c
@@ -312,13 +312,3 @@ rs232_get_rts(struct rs232_port_t *p)
 	DBG("p=%p rts: %d\n", (void *)p, p->rts);
 	return p->rts;
 }
-
-RS232_LIB unsigned int
-rs232_in_qeue(struct rs232_port_t *p, unsigned int *in_bytes){
-	return rs232_in_queue(p, in_bytes);
-}
-
-RS232_LIB void
-rs232_in_qeue_clear(struct rs232_port_t *p){
-	rs232_in_queue_clear(p);
-}

--- a/src/rs232_posix.c
+++ b/src/rs232_posix.c
@@ -9,10 +9,10 @@
  * copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following
  * conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -55,7 +55,7 @@ rs232_init(void)
 
 	memset(p->pt, 0, sizeof(struct rs232_posix_t));
 	memset(p->dev, 0, RS232_STRLEN_DEVICE+1);
-	strncpy(p->dev, RS232_PORT_POSIX, RS232_STRLEN_DEVICE);
+	strncpyz(p->dev, RS232_PORT_POSIX, RS232_STRLEN_DEVICE);
 
 	p->baud = RS232_BAUD_115200;
 	p->data = RS232_DATA_8;
@@ -72,7 +72,7 @@ rs232_init(void)
 void
 rs232_end(struct rs232_port_t *p)
 {
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p\n", (void *)p, p->pt);
 
@@ -101,7 +101,7 @@ rs232_in_queue(struct rs232_port_t *p, unsigned int *in_bytes)
 	int ret;
 	int b;
 	struct timeval tv;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p\n", (void *)p, p->pt);
 
@@ -138,14 +138,14 @@ rs232_in_queue_clear(struct rs232_port_t *p)
 	unsigned int blen;
 	unsigned char *buf = NULL;
 	struct timeval tv;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p\n", (void *)p, p->pt);
 
 	if (!rs232_port_open(p))
 		return;
 
-	rs232_in_qeue(p, &blen);
+	rs232_in_queue(p, &blen);
 	if (blen > 0) {
 		buf = (unsigned char*) malloc(blen * sizeof(unsigned char*)+1);
 		if (buf == NULL)
@@ -174,7 +174,7 @@ rs232_read(struct rs232_port_t *p, unsigned char *buf, unsigned int buf_len,
 	   unsigned int *read_len)
 {
 	int r;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p buf_len=%d\n", (void *)p, p->pt, buf_len);
 
@@ -215,7 +215,7 @@ rs232_read_timeout_forced(struct rs232_port_t *p, unsigned char *buf,
 	int reti;
 	fd_set set;
 	int r;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 	struct timeval tv;
 	struct timeval t1;
 	struct timeval t2;
@@ -300,7 +300,7 @@ rs232_read_timeout(struct rs232_port_t *p, unsigned char *buf,
 	fd_set set;
 	int r;
 	struct timeval tv;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p buf_len=%d timeout=%d\n", (void *)p, p->pt,
 		buf_len, timeout);
@@ -345,10 +345,10 @@ rs232_write(struct rs232_port_t *p, const unsigned char *buf, unsigned int buf_l
 		unsigned int *write_len)
 {
 	int w;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
-	DBG("p=%p p->pt=%p hex='%s' ascii='%s' buf_len=%d\n", 
-	    (void *)p, p->pt, rs232_hex_dump(buf, buf_len), 
+	DBG("p=%p p->pt=%p hex='%s' ascii='%s' buf_len=%d\n",
+	    (void *)p, p->pt, rs232_hex_dump(buf, buf_len),
 	    rs232_ascii_dump(buf, buf_len), buf_len);
 
 	if (!rs232_port_open(p))
@@ -378,7 +378,7 @@ rs232_write_timeout(struct rs232_port_t *p, const unsigned char *buf,
 	int ret;
 	fd_set set;
 	int w;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 	struct timeval tv;
 
 	DBG("p=%p p->pt=%p timeout=%d\n", (void *)p, p->pt, timeout);
@@ -424,7 +424,7 @@ rs232_open(struct rs232_port_t *p)
 {
 	int flags;
 	struct termios term;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p\n", (void *)p, p->pt);
 
@@ -434,7 +434,7 @@ rs232_open(struct rs232_port_t *p)
 		return RS232_ERR_OPEN;
 	}
 
-	/* 
+	/*
 	 * On OSX (and maybe on more systems), we need to open() the port with
 	 * O_NDELAY, because otherwise it would block forever waiting for DCD
 	 * signal, so here we restore back to blocking operations.
@@ -481,7 +481,7 @@ void
 rs232_set_device(struct rs232_port_t *p, const char *device)
 {
 	DBG("p=%p old=%s new=%s\n", (void *)p, p->dev, device);
-	strncpy(p->dev, device, RS232_STRLEN_DEVICE);
+	strncpyz(p->dev, device, RS232_STRLEN_DEVICE);
 	return;
 }
 
@@ -489,7 +489,7 @@ unsigned int
 rs232_set_baud(struct rs232_port_t *p, enum rs232_baud_e baud)
 {
 	struct termios term;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p baud=%d (%s bauds)\n",
 	    (void *)p, p->pt, baud, rs232_strbaud(baud));
@@ -551,7 +551,7 @@ rs232_set_dtr(struct rs232_port_t *p, enum rs232_dtr_e state)
 {
 	int ret;
 	int set;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p dtr=%d (dtr control %s)\n",
 	    (void *)p, p->pt, state, rs232_strdtr(state));
@@ -581,7 +581,7 @@ rs232_set_dtr(struct rs232_port_t *p, enum rs232_dtr_e state)
 		DBG("%s\n", "TIOCMSET RS232_ERR_IOCTL");
 		return RS232_ERR_IOCTL;
 	}
-	
+
 	p->dtr = state;
 
 	return RS232_ERR_NOERROR;
@@ -592,7 +592,7 @@ rs232_set_rts(struct rs232_port_t *p, enum rs232_rts_e state)
 {
 	int ret;
 	int set;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p rts=%d (rts control %s)\n",
 	    (void *)p, p->pt, state, rs232_strrts(state));
@@ -622,7 +622,7 @@ rs232_set_rts(struct rs232_port_t *p, enum rs232_rts_e state)
 		DBG("%s\n", "TIOCMSET RS232_ERR_IOCTL");
 		return RS232_ERR_IOCTL;
 	}
-	
+
 	p->rts = state;
 
 	return RS232_ERR_NOERROR;
@@ -632,7 +632,7 @@ unsigned int
 rs232_set_parity(struct rs232_port_t *p, enum rs232_parity_e parity)
 {
 	struct termios term;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p parity=%d (parity %s)\n",
 	    (void *)p, p->pt, parity, rs232_strparity(parity));
@@ -667,7 +667,7 @@ unsigned int
 rs232_set_stop(struct rs232_port_t *p, enum rs232_stop_e stop)
 {
 	struct termios term;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p stop=%d (%s stop bits)\n",
 	    (void *)p, p->pt, stop, rs232_strstop(stop));
@@ -698,7 +698,7 @@ unsigned int
 rs232_set_data(struct rs232_port_t *p, enum rs232_data_e data)
 {
 	struct termios term;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p data=%d (%s data bits)\n",
 	    (void *)p, p->pt, data, rs232_strdata(data));
@@ -736,7 +736,7 @@ unsigned int
 rs232_set_flow(struct rs232_port_t *p, enum rs232_flow_e flow)
 {
 	struct termios term;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p flow=%d (flow control %s)\n",
 	    (void *)p, p->pt, flow, rs232_strflow(flow));
@@ -773,7 +773,7 @@ unsigned int
 rs232_flush(struct rs232_port_t *p)
 {
 	int ret;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p\n", (void *)p, p->pt);
 
@@ -791,7 +791,7 @@ unsigned int
 rs232_close(struct rs232_port_t *p)
 {
 	int ret;
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p\n", (void *)p, p->pt);
 
@@ -809,7 +809,7 @@ rs232_close(struct rs232_port_t *p)
 unsigned int
 rs232_fd(struct rs232_port_t *p)
 {
-	struct rs232_posix_t *ux = p->pt;
+	struct rs232_posix_t *ux = (struct rs232_posix_t *)p->pt;
 
 	DBG("p=%p p->pt=%p ux->fd=%d\n", (void *)p, p->pt, ux->fd);
 

--- a/src/rs232_windows.c
+++ b/src/rs232_windows.c
@@ -117,7 +117,7 @@ rs232_init(void)
 	DBG("p=%p p->pt=%p\n", (void *)p, p->pt);
 
 	memset(p->dev, 0, RS232_STRLEN_DEVICE+1);
-	strncpy(p->dev, RS232_PORT_WIN32, RS232_STRLEN_DEVICE);
+	strncpyz(p->dev, RS232_PORT_WIN32, RS232_STRLEN_DEVICE);
 
 	p->baud = RS232_BAUD_115200;
 	p->data = RS232_DATA_8;
@@ -860,7 +860,7 @@ RS232_LIB void
 rs232_set_device(struct rs232_port_t *p, const char *device)
 {
 	DBG("p=%p old=%s new=%s\n", (void *)p, p->dev, device);
-	strncpy(p->dev, device, RS232_STRLEN_DEVICE);
+	strncpyz(p->dev, device, RS232_STRLEN_DEVICE);
 
 	return;
 }
@@ -1184,7 +1184,7 @@ rs232_fd(struct rs232_port_t *p)
 {
 	struct rs232_windows_t *wx = p->pt;
 
-	DBG("p=%p p->pt=%p wx->fd=%p\n", (void *)p, p->pt, wx->fd);
+	DBG("p=%p p->pt=%p wx->fd=%d\n", (void *)p, p->pt, wx->fd);
 
 	return (unsigned int) wx->fd;
 }


### PR DESCRIPTION
Add some casts to allow compile in c++
Ensure that destination on strncpy is always zero terminated
Remove wrapper functions rs232_in_queue and rs232_in_qeue_clear
